### PR TITLE
Multiple body tags, fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Contributors: stanton119
 Donate link: http://www.richard-stanton.com/Wordpress-HTML
 Tags: HTML, body, head, jQuery, ChartJS, D3js, Highcharts, Prototype
 Requires at least: 3.0.1
-Tested up to: 4.2.2
-Stable tag: 0.1
+Tested up to: 4.2.3
+Stable tag: 0.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -31,7 +31,7 @@ Code: [GitHub](https://github.com/stanton119/WordPress-HTML-Plugin)
 
 Upload the plugin to your blog and activate it.
 
-In the post/page which needs HTML add a custom field with name: "body", paste the HTML into the value box, then insert the shortcode [body][/body] where it should appear in the page.
+In the post/page which needs HTML add a custom field with name: "body", paste the HTML into the value box, then insert the shortcode [body][/body] where it should appear in the page. You can insert multiple body tags with the syntax: [body id="element1"][/body], where "element1" is the name of a custom field to insert.
 
 To add to the HTML head tag, add a custom field with name: "head" and paste the HTML into the value box.
 
@@ -47,6 +47,11 @@ To add a custom field, scroll down in the editor to Custom Fields. There is an o
 3. Adding a custom field
 
 == Changelog ==
+
+= 0.5 =
+*Release Date - 28th July, 2015*
+
+* Added ability for multiple body tags in a single post/page: [body id="element1"][/body], where "element1" is the name of a custom field to insert.
 
 = 0.1 =
 *Release Date - 14th February, 2015*

--- a/wordpress-html.php
+++ b/wordpress-html.php
@@ -2,18 +2,26 @@
 /**
  * Plugin Name: Wordpress HTML
  * Plugin URI: http://www.richard-stanton.com/Wordpress-HTML
- * Description: Add raw HTML to any post/page. In the post/page which needs HTML add a custom field with name: "body", paste the HTML into the value box, then insert the shortcode [body][/body] where it should appear in the page. To add to the HTML head tag, add a custom field with name: "head" and paste the HTML into the value box.
- * Version: 0.1
+ * Description: Add raw HTML to any post/page. In the post/page which needs HTML add a custom field with name: "body", paste the HTML into the value box, then insert the shortcode [body][/body] where it should appear in the page. To add to the HTML head tag, add a custom field with name: "head" and paste the HTML into the value box. To add multiple [body] tags the syntax [body id="element1"][/body] can be used, where "element1" is the name of a custom field.
+ * Version: 0.5
  * Author: Richard Stanton
  * Author URI: http://www.richard-stanton.com
  * License: GPL2
  */
 
+// [body id="element1"]
 function bodyhtml($atts, $content = null) {
 	global $post;
 	if(!empty($post)){
+		// take in attribute, find post_meta with corresponding attribute, post into page
+		
+	    $a = shortcode_atts( array(
+			// by default use 'body'
+	        'id' => 'body',
+	    ), $atts );
+		
 		// get custom field for 'body'
-		$bodyHTML = get_post_meta($post->ID, 'body', true);
+		$bodyHTML = get_post_meta($post->ID, $a['id'], true);
 		if(!empty($bodyHTML)){
 			// insert into body
 			return $bodyHTML;

--- a/wordpress-html.php
+++ b/wordpress-html.php
@@ -20,7 +20,7 @@ function bodyhtml($atts, $content = null) {
 		}
 	}
 }
-add_shortcode('body', 'bodyhtml');
+add_shortcode('body', 'bodyhtml');	// adds shortcode 'body' when used, implements function 'bodyhtml'
 
 function headhtml(){
 	global $post;


### PR DESCRIPTION
Added ability to use multiple body tags:
`[body id="element1"][/body]`, where "element1" is the name of a custom field to insert.
